### PR TITLE
Feat: Support Both Kustomer Org Name and ID Via New Commands

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,3 +1,4 @@
 mod urls;
 
 pub mod org_domain;
+pub mod org_id;

--- a/src/api/org_domain.rs
+++ b/src/api/org_domain.rs
@@ -26,9 +26,9 @@ pub async fn get_org_domain_data(org_name: &String) -> Result<OrgDomainResponse,
 
 /// TODO: Implement an API call to the Kustomer API by their Org ID. This data
 /// will include a more detailed org output and will require an API key for production. 
-pub async fn get_full_org_data(_org_domain_data: &OrgDomainResponse) -> Result<(), Box<dyn Error>> {
-    // let kustomer_api_key = env::var("KUSTOMER_API_KEY")
-    print!("");
+pub async fn get_full_org_data(org_id: &String, api_key: &String) -> Result<(), Box<dyn Error>> {
+    println!("{} is the ID and {} is the key", org_id, api_key);
+
 
     Ok(())
 }

--- a/src/api/org_domain.rs
+++ b/src/api/org_domain.rs
@@ -3,11 +3,12 @@ use reqwest::Client;
 
 use crate::models::org_domain_request::OrgDomainRequest;
 use crate::models::org_domain_response::OrgDomainResponse;
+use crate::models::shared::SharedResponse;
 use super::urls::KUSTOMER_API;
 
 /// Obtains top level domain data for the specific org, such the org's id
 /// and the name associated with that org.
-pub async fn get_org_domain_data(org_name: &String) -> Result<OrgDomainResponse, Box<dyn Error>> {
+pub async fn get_org_domain_data(org_name: &String) -> Result<SharedResponse, Box<dyn Error>> {
     let org_name = org_name.clone();
 
     let req = OrgDomainRequest::new(org_name);
@@ -20,8 +21,10 @@ pub async fn get_org_domain_data(org_name: &String) -> Result<OrgDomainResponse,
         .await?
         .json::<OrgDomainResponse>()
         .await?;
+    
+    let final_response = SharedResponse::new(resp.data.attributes.org_id, resp.data.attributes.name, Some(resp.data.attributes.pod));
 
-    Ok(resp)
+    Ok(final_response)
 }
 
 /// TODO: Implement an API call to the Kustomer API by their Org ID. This data

--- a/src/api/org_domain.rs
+++ b/src/api/org_domain.rs
@@ -26,12 +26,3 @@ pub async fn get_org_domain_data(org_name: &String) -> Result<SharedResponse, Bo
 
     Ok(final_response)
 }
-
-/// TODO: Implement an API call to the Kustomer API by their Org ID. This data
-/// will include a more detailed org output and will require an API key for production. 
-pub async fn get_full_org_data(org_id: &String, api_key: &String) -> Result<(), Box<dyn Error>> {
-    println!("{} is the ID and {} is the key", org_id, api_key);
-
-
-    Ok(())
-}

--- a/src/api/org_id.rs
+++ b/src/api/org_id.rs
@@ -1,0 +1,36 @@
+use reqwest::Client;
+use std::error::Error;
+
+use crate::models::{org_data_response::OrgDataResponse, org_data_request::{OrgDataRequest}, org_domain_response::OrgDomainResponse, org_domain_request::OrgDomainRequest, shared::SharedResponse};
+
+use super::urls::KUSTOMER_API;
+
+pub async fn get_org_data_by_id(org_id: &String, api_key: &String) -> Result<SharedResponse, Box<dyn Error>> {
+    let client = Client::new();
+    
+    // Make Request to Org Data Internal Endpoint with API Key
+    let org_data_request = OrgDataRequest::new(org_id.clone(), api_key.clone());
+    let url = org_data_request.generate_url(KUSTOMER_API);
+
+    
+    let org_data_resp = client.get(&url)
+    .bearer_auth(org_data_request.api_key)
+    .send()
+    .await?
+    .json::<OrgDataResponse>()
+    .await?;
+    
+    // Make Request to Org Domain Endpoint when we have the name of the org
+    let org_domain_request = OrgDomainRequest::new(org_data_resp.data.attributes.name);
+    let url = org_domain_request.generate_url(KUSTOMER_API);
+
+    let org_domain_resp = client.get(&url)
+    .send()
+    .await?
+    .json::<OrgDomainResponse>()
+    .await?;
+
+    let final_resp = SharedResponse::new(org_domain_resp.data.attributes.org_id, org_domain_resp.data.attributes.name, Some(org_domain_resp.data.attributes.pod));
+
+    Ok(final_resp)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,5 +3,5 @@ mod models;
 mod output;
 
 pub use crate::api::org_domain::get_org_domain_data;
-pub use crate::api::org_domain::get_full_org_data;
+pub use crate::api::org_id::get_org_data_by_id;
 pub use crate::output::print::print_org_domain_response;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ use std::{error::Error, env};
 use clap::{Parser, Subcommand};
 use colored::Colorize;
 
-use kustomer_org::{get_org_domain_data, get_full_org_data, print_org_domain_response};
+use kustomer_org::{get_org_domain_data, get_org_data_by_id, print_org_domain_response};
 
 static KUSTOMER_API_KEY: &'static str = "KUSTOMER_API_KEY";
 
@@ -65,6 +65,7 @@ async fn run(org_data: &KustomerOrgData) -> Result<(), Box<dyn Error>> {
     }
 }
 
+/// Parses data by org name passed into the CLI
 async fn parse_by_org_name(org_name: String) -> Result<(), Box<dyn Error>> {
     let org_name_lower = org_name.to_lowercase();
     let org_name_upper = org_name.to_uppercase();
@@ -84,6 +85,7 @@ async fn parse_by_org_name(org_name: String) -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
+/// Parses data by org ID and Kustomer API Key passed into the CLI
 async fn parse_by_org_id(id: String, api_key: Option<String>) -> Result<(), Box<dyn Error>> {
     let finalized_api_key = api_key.clone().unwrap_or_else(|| {
         let key_from_env = env::var(KUSTOMER_API_KEY);
@@ -96,13 +98,24 @@ async fn parse_by_org_id(id: String, api_key: Option<String>) -> Result<(), Box<
 
     // Handle the error case when there are no API keys specified
     if finalized_api_key.is_empty() {
-        let error_message = format!("You must have an environment variable with the name KUSTOMER_API_KEY set or pass an API Key via the flag").red();
+        let error_message = format!("You must have an environment variable with the name KUSTOMER_API_KEY set or pass an API Key via the --api-key CLI flag").red();
         println!("{error_message}");
         return Ok(())
     }
 
     // Make Request for Org Data
-    get_full_org_data(&id, &finalized_api_key).await?;
+    let res = get_org_data_by_id(&id, &finalized_api_key).await;
+
+    match res {
+        Ok(org_data_response) =>  {
+            // Output data for org
+            print_org_domain_response(&org_data_response);
+        },
+        Err(_e) => {
+            let error_message = format!("Having trouble fetching Kustomer org data for org {}", id).red();
+            println!("{error_message}");
+        }
+    }
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,17 +1,41 @@
-use std::error::Error;
-use clap::Parser;
+use std::{error::Error, env};
+use clap::{Parser, Subcommand};
 use colored::Colorize;
 
 use kustomer_org::{get_org_domain_data, get_full_org_data, print_org_domain_response};
 
+static KUSTOMER_API_KEY: &'static str = "KUSTOMER_API_KEY";
+
 #[derive(Debug, Parser)]
 #[command(name = "kustomer-org", about = "Kustomer Org Data Getter")]
 pub struct KustomerOrgData {
+    #[command(subcommand)]
+    org_data_action: OrgDataAction,
+}
+
+#[derive(Debug, Subcommand)]
+enum OrgDataAction {
     /// Obtains the org data within prod1 and prod2 environments by the
     /// corresponding org name.
-    #[arg(short, long)]
-    org_name: String,
+    DataByOrgName {
+        /// Finds the org by the name provided
+        #[arg(short, long)]
+        name: String
+    },
+    /// Obtains the org data within prod1 and prod2 environments by the
+    /// corresponding org ID and production API key.
+    DataByOrgId {
+        /// Finds the org by the name provided
+        #[arg(long)]
+        id: String,
+
+        /// If an API key for production is not provided, we will fallback
+        /// on the environment variables assigned on your machine
+        #[arg(long)]
+        api_key: Option<String>
+    },
 }
+
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
@@ -27,24 +51,58 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
 async fn run(org_data: &KustomerOrgData) -> Result<(), Box<dyn Error>> {
     match org_data {
-        KustomerOrgData { org_name } => {
-            let org_name_lower = org_name.to_lowercase();
-            let org_name_upper = org_name.to_uppercase();
-            let domain = get_org_domain_data(&org_name_lower).await;
-
-            match domain {
-                Ok(org_domain_data) => {
-                    // Output data for org
-                    print_org_domain_response(&org_domain_data);
-                    get_full_org_data(&org_domain_data).await?;
-                }
-                Err(_e) => {
-                    let error_message = format!("Having trouble fetching Kustomer org data for org {}", org_name_upper).red();
-                    println!("{error_message}");
+        KustomerOrgData { org_data_action } => {
+            match org_data_action {
+                OrgDataAction::DataByOrgName { name } => {
+                    parse_by_org_name(name).await?
+                },
+                OrgDataAction::DataByOrgId { id, api_key } => {
+                    parse_by_org_id(id, api_key).await?
                 }
             }
-            
             Ok(())
         }
     }
+}
+
+async fn parse_by_org_name(org_name: &String) -> Result<(), Box<dyn Error>> {
+    let org_name_lower = org_name.to_lowercase();
+    let org_name_upper = org_name.to_uppercase();
+    let domain = get_org_domain_data(&org_name_lower).await;
+
+    match domain {
+        Ok(org_domain_data) => {
+            // Output data for org
+            print_org_domain_response(&org_domain_data);
+        }
+        Err(_e) => {
+            let error_message = format!("Having trouble fetching Kustomer org data for org {}", org_name_upper).red();
+            println!("{error_message}");
+        }
+    }
+
+    Ok(())
+}
+
+async fn parse_by_org_id(id: &String, api_key: &Option<String>) -> Result<(), Box<dyn Error>> {
+    let finalized_api_key = api_key.clone().unwrap_or_else(|| {
+        let key_from_env = env::var(KUSTOMER_API_KEY);
+
+        match key_from_env {
+            Ok(k) => k,
+            Err(_) => String::new()
+        }
+    });
+
+    // Handle the error case when there are no API keys specified
+    if finalized_api_key.is_empty() {
+        let error_message = format!("You must have an environment variable with the name KUSTOMER_API_KEY set or pass an API Key via the flag").red();
+        println!("{error_message}");
+        return Ok(())
+    }
+
+    // Make Request for Org Data
+    get_full_org_data(id, &finalized_api_key).await?;
+
+    Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,10 +54,10 @@ async fn run(org_data: &KustomerOrgData) -> Result<(), Box<dyn Error>> {
         KustomerOrgData { org_data_action } => {
             match org_data_action {
                 OrgDataAction::DataByOrgName { name } => {
-                    parse_by_org_name(name).await?
+                    parse_by_org_name(name.to_owned()).await?
                 },
                 OrgDataAction::DataByOrgId { id, api_key } => {
-                    parse_by_org_id(id, api_key).await?
+                    parse_by_org_id(id.to_owned(), api_key.to_owned()).await?
                 }
             }
             Ok(())
@@ -65,7 +65,7 @@ async fn run(org_data: &KustomerOrgData) -> Result<(), Box<dyn Error>> {
     }
 }
 
-async fn parse_by_org_name(org_name: &String) -> Result<(), Box<dyn Error>> {
+async fn parse_by_org_name(org_name: String) -> Result<(), Box<dyn Error>> {
     let org_name_lower = org_name.to_lowercase();
     let org_name_upper = org_name.to_uppercase();
     let domain = get_org_domain_data(&org_name_lower).await;
@@ -84,7 +84,7 @@ async fn parse_by_org_name(org_name: &String) -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-async fn parse_by_org_id(id: &String, api_key: &Option<String>) -> Result<(), Box<dyn Error>> {
+async fn parse_by_org_id(id: String, api_key: Option<String>) -> Result<(), Box<dyn Error>> {
     let finalized_api_key = api_key.clone().unwrap_or_else(|| {
         let key_from_env = env::var(KUSTOMER_API_KEY);
 
@@ -102,7 +102,7 @@ async fn parse_by_org_id(id: &String, api_key: &Option<String>) -> Result<(), Bo
     }
 
     // Make Request for Org Data
-    get_full_org_data(id, &finalized_api_key).await?;
+    get_full_org_data(&id, &finalized_api_key).await?;
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ use colored::Colorize;
 
 use kustomer_org::{get_org_domain_data, get_org_data_by_id, print_org_domain_response};
 
-static KUSTOMER_API_KEY: &'static str = "KUSTOMER_API_KEY";
+static KUSTOMER_PROD_API_KEY: &'static str = "KUSTOMER_PROD_API_KEY";
 
 #[derive(Debug, Parser)]
 #[command(name = "kustomer-org", about = "Kustomer Org Data Getter")]
@@ -30,7 +30,7 @@ enum OrgDataAction {
         id: String,
 
         /// If an API key for production is not provided, we will fallback
-        /// on the environment variables assigned on your machine
+        /// on the KUSTOMER_PROD_API_KEY environment variable assigned on your machine
         #[arg(long)]
         api_key: Option<String>
     },
@@ -88,7 +88,7 @@ async fn parse_by_org_name(org_name: String) -> Result<(), Box<dyn Error>> {
 /// Parses data by org ID and Kustomer API Key passed into the CLI
 async fn parse_by_org_id(id: String, api_key: Option<String>) -> Result<(), Box<dyn Error>> {
     let finalized_api_key = api_key.clone().unwrap_or_else(|| {
-        let key_from_env = env::var(KUSTOMER_API_KEY);
+        let key_from_env = env::var(KUSTOMER_PROD_API_KEY);
 
         match key_from_env {
             Ok(k) => k,
@@ -98,7 +98,7 @@ async fn parse_by_org_id(id: String, api_key: Option<String>) -> Result<(), Box<
 
     // Handle the error case when there are no API keys specified
     if finalized_api_key.is_empty() {
-        let error_message = format!("You must have an environment variable with the name KUSTOMER_API_KEY set or pass an API Key via the --api-key CLI flag").red();
+        let error_message = format!("You must have an environment variable with the name KUSTOMER_PROD_API_KEY set or pass an API Key via the --api-key CLI flag").red();
         println!("{error_message}");
         return Ok(())
     }

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,3 +1,5 @@
 pub mod org_domain_request;
 pub mod org_domain_response;
+pub mod org_data_request;
+pub mod org_data_response;
 pub mod shared;

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,2 +1,3 @@
 pub mod org_domain_request;
 pub mod org_domain_response;
+pub mod shared;

--- a/src/models/org_data_request.rs
+++ b/src/models/org_data_request.rs
@@ -1,0 +1,14 @@
+pub struct OrgDataRequest {
+    pub org_id: String,
+    pub api_key: String
+}
+
+impl OrgDataRequest {
+    pub fn new(org_id: String, api_key: String) -> Self {
+        OrgDataRequest { org_id, api_key }
+    } 
+    
+    pub fn generate_url(&self, base_url: &'static str) -> String {
+        format!("{}/v1/orgs/{}", base_url, self.org_id)
+    }
+}

--- a/src/models/org_data_response.rs
+++ b/src/models/org_data_response.rs
@@ -1,0 +1,55 @@
+use serde::{Serialize, Deserialize};
+
+#[derive(Serialize, Deserialize)]
+pub struct OrgDataResponse {
+    #[serde(rename = "data")]
+    pub data: Data,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct Data {
+    #[serde(rename = "type")]
+    pub data_type: String,
+
+    #[serde(rename = "id")]
+    pub id: String,
+
+    #[serde(rename = "attributes")]
+    pub attributes: Attributes,
+
+    #[serde(rename = "links")]
+    pub links: Links,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct Attributes {
+    #[serde(rename = "displayName")]
+    pub display_name: String,
+
+    #[serde(rename = "name")]
+    pub name: String,
+
+    #[serde(rename = "meta")]
+    pub meta: Meta,
+
+    #[serde(rename = "createdAt")]
+    pub created_at: String,
+
+    #[serde(rename = "updatedAt")]
+    pub updated_at: String,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct Meta {
+    #[serde(rename = "registeredIpAddress")]
+    pub registered_ip_address: String,
+
+    #[serde(rename = "registeredExternal")]
+    pub registered_external: bool,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct Links {
+    #[serde(rename = "self")]
+    pub links_self: String,
+}

--- a/src/models/shared.rs
+++ b/src/models/shared.rs
@@ -1,0 +1,11 @@
+pub struct SharedResponse {
+    pub org_id: String,
+    pub org_name: String,
+    pub pod: Option<String>
+}
+
+impl SharedResponse {
+    pub fn new(org_id: String, org_name: String, pod: Option<String>) -> Self {
+        SharedResponse { org_id: org_id, org_name: org_name, pod }
+    }
+}

--- a/src/output/print.rs
+++ b/src/output/print.rs
@@ -1,12 +1,17 @@
 use colored::Colorize;
 
-use crate::models::org_domain_response::OrgDomainResponse;
+use crate::models::{shared::SharedResponse};
 
-pub fn print_org_domain_response(domain_response: &OrgDomainResponse) {
-    let org_id = domain_response.data.attributes.org_id.clone();
-    let org_name = domain_response.data.attributes.name.clone();
-    let org_name = org_name.to_uppercase();
-    let pod_name = domain_response.data.attributes.pod.to_uppercase();
+pub fn print_org_domain_response(shared_response: &SharedResponse) {
+    let org_id = shared_response.org_id.clone();
+    let org_name = shared_response.org_name.to_uppercase();
+
+    let mut pod_name = String::from("not found");
+
+    if let Some(pod) = &shared_response.pod {
+        pod_name = pod.clone();
+    }
+
 
     let success_message = format!("{} has Org ID: {} in Pod: {}", org_name, org_id, pod_name).green();
     println!("{success_message}");


### PR DESCRIPTION
- feat: begin parsing org id ane environment variable
- fix: ownership
- fix: pod using optional
- feat: parsing org data by name and id
- fix: use kustomer prod api key name for env var
